### PR TITLE
Add autoSaveYaml setting — decouple visual width changes from file mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Enable under **Settings → Control mode → Pills**. The status bar shows three
 | **px range** | Min / max for pixel unit | `100 / 4000` |
 | **ch range** | Min / max for character unit | `10 / 200` |
 | **Enable per-note width** | Store widths in YAML frontmatter | `on` |
+| **Automatically save to YAML** *(per-note mode)* | Persist width changes to YAML frontmatter. Turn off to adjust the width visually for this session only, without modifying the file — useful in shared vaults | `on` |
 | **YAML front matter key** | Key used for per-note widths | `custom-width` |
 | **Enable code block width** | Give code blocks an independent width | `off` |
 | **Code block width unit** | Unit for code block width | `px` |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Control the line width of every note in Obsidian — individually, per note, or 
 
 ## Features
 
-- **Per-note widths** via YAML frontmatter
+- **Per-note widths** — stored in the note's frontmatter, kept locally on your device, or held only until the note is closed
 - **Status-bar controls** — choose between a classic slider or *Pills* (three preset buttons)
 - **Three width units** — `%`, `px`, `ch`
 - **Independent code block width** — so narrow prose and wide code can coexist
@@ -77,9 +77,10 @@ Enable under **Settings → Control mode → Pills**. The status bar shows three
 | **% range** | Min / max for percentage unit | `0 / 100` |
 | **px range** | Min / max for pixel unit | `100 / 4000` |
 | **ch range** | Min / max for character unit | `10 / 200` |
-| **Enable per-note width** | Store widths in YAML frontmatter | `on` |
-| **Automatically save to YAML** *(per-note mode)* | Persist width changes to YAML frontmatter. Turn off to adjust the width visually for this session only, without modifying the file — useful in shared vaults | `on` |
-| **YAML front matter key** | Key used for per-note widths | `custom-width` |
+| **Enable per-note width** | Let notes have their own width instead of the global default | `on` |
+| **Where per-note width is stored** *(per-note mode)* | Frontmatter (in the note), Local (kept in the plugin, note untouched), or View only (kept until the note is closed) | `frontmatter` |
+| **Reset local width overrides** *(local mode)* | Removes every per-note width you have stored locally | button |
+| **YAML front matter key** | Frontmatter key used to store the per-note width | `custom-width` |
 | **Enable code block width** | Give code blocks an independent width | `off` |
 | **Code block width unit** | Unit for code block width | `px` |
 | **Code block width** | Size applied to code blocks | `800` |

--- a/src/event/eventHandler.ts
+++ b/src/event/eventHandler.ts
@@ -113,7 +113,8 @@ export default class EventHandler
 	 */
 	private saveWidth(wv: WidthValue): void
 	{
-		if (this.plugin.settingsManager.getEnablePerNoteWidth())
+		if (this.plugin.settingsManager.getEnablePerNoteWidth()
+			&& this.plugin.settingsManager.getAutoSaveYaml())
 		{
 			// Per-note: debounce save to YAML frontmatter
 			if (this.updateTimeout) clearTimeout(this.updateTimeout);

--- a/src/event/eventHandler.ts
+++ b/src/event/eventHandler.ts
@@ -1,7 +1,7 @@
-import { App, Notice, WorkspaceLeaf } from "obsidian";
+import { App, Notice, TAbstractFile, TFile, WorkspaceLeaf } from "obsidian";
 import CustomNoteWidth from "src/main";
 import { t } from "src/i18n/i18n";
-import { isActiveLeafMarkdown, validateWidth } from "src/utility/utilities";
+import { getActiveMarkdownView, isActiveLeafMarkdown, validateWidth } from "src/utility/utilities";
 import { CONFIG, WidthUnit, WidthValue, formatWidthForYaml } from "src/utility/config";
 
 /**
@@ -29,6 +29,8 @@ export default class EventHandler
 		this.plugin.registerEvent(this.app.workspace.on("resize", this.handleResize));
 		this.plugin.registerEvent(this.app.workspace.on("active-leaf-change", this.handleActiveLeafChange));
 		this.plugin.registerEvent(this.app.workspace.on("layout-change", this.handleLayoutChange));
+		this.plugin.registerEvent(this.app.vault.on("rename", this.handleFileRename));
+		this.plugin.registerEvent(this.app.vault.on("delete", this.handleFileDelete));
 	}
 
 	/**
@@ -42,6 +44,10 @@ export default class EventHandler
 		this.app.workspace.off("active-leaf-change", this.handleActiveLeafChange as any);
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		this.app.workspace.off("layout-change", this.handleLayoutChange as any);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		this.app.vault.off("rename", this.handleFileRename as any);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		this.app.vault.off("delete", this.handleFileDelete as any);
 	}
 
 	/**
@@ -96,42 +102,58 @@ export default class EventHandler
 	};
 
 	/**
-	 * Handles the layout-change event.
-	 * Suppressed briefly after YAML writes to avoid stale metadataCache reads.
+	 * Handles the layout-change event: drops view-only widths for files that are no
+	 * longer open in any leaf, then re-applies width for the active leaf (unless a
+	 * recent YAML write asked to suppress this cycle to avoid a stale metadataCache read).
 	 */
 	private handleLayoutChange = (): void =>
 	{
+		this.plugin.noteWidthManager.cleanupViewOnlyWidths();
 		if (this.layoutChangeSuppressed) return;
 		this.plugin.noteWidthManager.applyWidthForLeaf();
 	};
 
+	/** Moves per-note storage to the new path so a later note at the old path cannot inherit it. */
+	private handleFileRename = async (file: TAbstractFile, oldPath: string): Promise<void> =>
+	{
+		if (!(file instanceof TFile)) return;
+		await this.plugin.settingsManager.renameLocalOverride(oldPath, file.path);
+		this.plugin.noteWidthManager.renameViewOnlyWidth(oldPath, file.path);
+	};
+
+	/** Drops per-note storage for a deleted file so its path cannot be inherited. */
+	private handleFileDelete = async (file: TAbstractFile): Promise<void> =>
+	{
+		if (!(file instanceof TFile)) return;
+		await this.plugin.settingsManager.clearLocalOverride(file.path);
+		this.plugin.noteWidthManager.clearViewOnlyWidth(file.path);
+	};
+
 	/**
-	 * Saves the width value based on the current per-note setting.
-	 * If per-note width is enabled:
-	 *   - with auto-save to YAML on: debounces a YAML frontmatter write
-	 *   - with auto-save off: stores the width in memory for this session only
-	 * If per-note width is disabled, saves as the default width.
+	 * Persists a width change from the status bar, according to the current per-note mode.
+	 * With per-note width disabled the value becomes the global default.
 	 * @param wv - The WidthValue to save.
 	 */
 	private saveWidth(wv: WidthValue): void
 	{
 		if (this.plugin.settingsManager.getEnablePerNoteWidth())
 		{
-			const file = this.app.workspace.getActiveFile();
+			const mode = this.plugin.settingsManager.getPerNoteMode();
+			const file = getActiveMarkdownView(this.app)?.file ?? null;
 
-			// Per-note: auto-save to YAML disabled — keep the width in memory
-			// for this session only (visual adjustment without touching the file).
-			if (!this.plugin.settingsManager.getAutoSaveYaml())
+			if (mode === 'local')
 			{
-				if (file) this.plugin.noteWidthManager.setTempWidth(file.path, wv);
+				if (file) void this.plugin.settingsManager.setLocalOverride(file.path, wv);
 				return;
 			}
 
-			// Drop any stale session-only width for this note: the YAML
-			// frontmatter becomes authoritative again.
-			if (file) this.plugin.noteWidthManager.clearTempWidth(file.path);
+			if (mode === 'view-only')
+			{
+				if (file) this.plugin.noteWidthManager.setViewOnlyWidth(file.path, wv);
+				return;
+			}
 
-			// Per-note: debounce save to YAML frontmatter
+			// 'frontmatter' mode: debounced YAML write.
 			if (this.updateTimeout) clearTimeout(this.updateTimeout);
 			this.updateTimeout = window.setTimeout(async () =>
 			{

--- a/src/event/eventHandler.ts
+++ b/src/event/eventHandler.ts
@@ -107,15 +107,30 @@ export default class EventHandler
 
 	/**
 	 * Saves the width value based on the current per-note setting.
-	 * If per-note width is enabled, debounces a YAML write.
-	 * If disabled, saves as the default width.
+	 * If per-note width is enabled:
+	 *   - with auto-save to YAML on: debounces a YAML frontmatter write
+	 *   - with auto-save off: stores the width in memory for this session only
+	 * If per-note width is disabled, saves as the default width.
 	 * @param wv - The WidthValue to save.
 	 */
 	private saveWidth(wv: WidthValue): void
 	{
-		if (this.plugin.settingsManager.getEnablePerNoteWidth()
-			&& this.plugin.settingsManager.getAutoSaveYaml())
+		if (this.plugin.settingsManager.getEnablePerNoteWidth())
 		{
+			const file = this.app.workspace.getActiveFile();
+
+			// Per-note: auto-save to YAML disabled — keep the width in memory
+			// for this session only (visual adjustment without touching the file).
+			if (!this.plugin.settingsManager.getAutoSaveYaml())
+			{
+				if (file) this.plugin.noteWidthManager.setTempWidth(file.path, wv);
+				return;
+			}
+
+			// Drop any stale session-only width for this note: the YAML
+			// frontmatter becomes authoritative again.
+			if (file) this.plugin.noteWidthManager.clearTempWidth(file.path);
+
 			// Per-note: debounce save to YAML frontmatter
 			if (this.updateTimeout) clearTimeout(this.updateTimeout);
 			this.updateTimeout = window.setTimeout(async () =>

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -101,7 +101,7 @@ const en: Translations = {
 	"settings.enable_per_note.name": "Enable per-note width",
 	"settings.enable_per_note.desc": "Enable to set individual widths per note via YAML frontmatter.",
 	"settings.auto_save_yaml.name": "Automatically save to YAML",
-	"settings.auto_save_yaml.desc": "When enabled, slider changes are immediately saved to the note's YAML frontmatter. Disable to use the slider without modifying the file.",
+	"settings.auto_save_yaml.desc": "When enabled, width adjustments are written to the note's YAML frontmatter. Disable to adjust the width for this session only, without modifying the file.",
 	"settings.yaml_key.name": "YAML front matter key",
 	"settings.yaml_key.desc": "Specify the YAML front matter key to use for setting the custom width of the editor.",
 
@@ -181,7 +181,7 @@ const de: Translations = {
 	"settings.enable_per_note.name": "Individuelle Notizbreite",
 	"settings.enable_per_note.desc": "Individuelle Breite pro Notiz per YAML-Frontmatter setzen.",
 	"settings.auto_save_yaml.name": "Automatisch in YAML speichern",
-	"settings.auto_save_yaml.desc": "Wenn aktiviert, werden Schieberegler-Änderungen sofort im YAML-Frontmatter gespeichert. Deaktivieren, um den Schieberegler ohne Dateiänderung zu nutzen.",
+	"settings.auto_save_yaml.desc": "Wenn aktiviert, werden Breitenänderungen im YAML-Frontmatter der Notiz gespeichert. Deaktivieren, um die Breite nur für diese Sitzung anzupassen, ohne die Datei zu verändern.",
 	"settings.yaml_key.name": "YAML-Frontmatter-Schlüssel",
 	"settings.yaml_key.desc": "YAML-Frontmatter-Schlüssel für die individuelle Breite festlegen.",
 
@@ -261,7 +261,7 @@ const ru: Translations = {
 	"settings.enable_per_note.name": "Включить индивидуальную ширину заметок",
 	"settings.enable_per_note.desc": "Разрешить задавать отдельную ширину для каждой заметки через свойства заметки.",
 	"settings.auto_save_yaml.name": "Автоматически сохранять в YAML",
-	"settings.auto_save_yaml.desc": "Когда включено, изменения ползунка сразу сохраняются в YAML-свойства заметки. Отключите, чтобы использовать ползунок без изменения файла.",
+	"settings.auto_save_yaml.desc": "Когда включено, изменения ширины сохраняются в YAML-свойства заметки. Отключите, чтобы менять ширину только на время сеанса, не изменяя файл.",
 	"settings.yaml_key.name": "Ключ YAML свойства заметки",
 	"settings.yaml_key.desc": "Укажите ключ YAML свойства заметки для управления шириной редактора.",
 

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -64,6 +64,14 @@ const en: Translations = {
 
 	// Notices
 	"notice.slider_too_large": "Slider too large!",
+	"notice.local_overrides_cleared": "Removed {{count}} local width override(s).",
+	"notice.local_overrides_empty": "No local width overrides to clear.",
+	"modal.reset_overrides.title": "Reset local width overrides",
+	"modal.reset_overrides.desc": "{{count}} note(s) have a locally stored width. Pick which ones to remove.",
+	"modal.reset_overrides.search_placeholder": "Filter by path…",
+	"modal.reset_overrides.select_all": "Select all",
+	"modal.reset_overrides.empty_filter": "No matches.",
+	"modal.reset_overrides.remove": "Remove {{count}}",
 
 	// Progress modals
 	"progress.changing_keys": "Changing all YAML-Frontmatter keys...",
@@ -99,11 +107,17 @@ const en: Translations = {
 
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Enable per-note width",
-	"settings.enable_per_note.desc": "Enable to set individual widths per note via YAML frontmatter.",
-	"settings.auto_save_yaml.name": "Automatically save to YAML",
-	"settings.auto_save_yaml.desc": "When enabled, width adjustments are written to the note's YAML frontmatter. Disable to adjust the width for this session only, without modifying the file.",
+	"settings.enable_per_note.desc": "When on, notes can have their own width instead of using the global default.",
+	"settings.per_note_mode.name": "Where per-note width is stored",
+	"settings.per_note_mode.desc": "Choose where per-note widths live. 'Frontmatter' writes them into the note itself. 'Locally' saves them per note inside the plugin without touching the file. 'View only' keeps the change until the note is closed, then discards it.",
+	"settings.per_note_mode.option.frontmatter": "Frontmatter",
+	"settings.per_note_mode.option.local": "Locally",
+	"settings.per_note_mode.option.view_only": "View only",
+	"settings.reset_local_overrides.name": "Reset local width overrides",
+	"settings.reset_local_overrides.desc": "Remove every per-note width you have stored locally.",
+	"settings.reset_local_overrides.button": "Reset",
 	"settings.yaml_key.name": "YAML front matter key",
-	"settings.yaml_key.desc": "Specify the YAML front matter key to use for setting the custom width of the editor.",
+	"settings.yaml_key.desc": "Frontmatter key used to store the per-note width.",
 
 	// Settings — Code Block
 	"settings.enable_code_block.name": "Enable code block width",
@@ -144,6 +158,14 @@ const de: Translations = {
 
 	// Notices
 	"notice.slider_too_large": "Schieberegler zu gro\u00DF!",
+	"notice.local_overrides_cleared": "{{count}} lokale Breite(n) entfernt.",
+	"notice.local_overrides_empty": "Keine lokalen Breiten zum Zur\u00FCcksetzen.",
+	"modal.reset_overrides.title": "Lokale Notizbreiten zur\u00FCcksetzen",
+	"modal.reset_overrides.desc": "{{count}} Notiz(en) haben eine lokal gespeicherte Breite. W\u00E4hle aus, welche entfernt werden sollen.",
+	"modal.reset_overrides.search_placeholder": "Nach Pfad filtern\u2026",
+	"modal.reset_overrides.select_all": "Alle ausw\u00E4hlen",
+	"modal.reset_overrides.empty_filter": "Keine Treffer.",
+	"modal.reset_overrides.remove": "{{count}} entfernen",
 
 	// Progress modals
 	"progress.changing_keys": "YAML-Frontmatter-Schl\u00FCssel werden ge\u00E4ndert\u2026",
@@ -179,11 +201,17 @@ const de: Translations = {
 
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Individuelle Notizbreite",
-	"settings.enable_per_note.desc": "Individuelle Breite pro Notiz per YAML-Frontmatter setzen.",
-	"settings.auto_save_yaml.name": "Automatisch in YAML speichern",
-	"settings.auto_save_yaml.desc": "Wenn aktiviert, werden Breitenänderungen im YAML-Frontmatter der Notiz gespeichert. Deaktivieren, um die Breite nur für diese Sitzung anzupassen, ohne die Datei zu verändern.",
+	"settings.enable_per_note.desc": "Wenn aktiviert, können Notizen eine eigene Breite statt der globalen Standardbreite haben.",
+	"settings.per_note_mode.name": "Wo die Notizbreite gespeichert wird",
+	"settings.per_note_mode.desc": "Wähle, wo Notizbreiten liegen. 'Frontmatter' schreibt sie in die Notiz selbst. 'Lokal' speichert sie pro Notiz im Plugin, ohne die Datei anzufassen. 'Nur in der Ansicht' behält die Änderung, bis die Notiz geschlossen wird, dann wird sie verworfen.",
+	"settings.per_note_mode.option.frontmatter": "Frontmatter",
+	"settings.per_note_mode.option.local": "Lokal",
+	"settings.per_note_mode.option.view_only": "Nur in der Ansicht",
+	"settings.reset_local_overrides.name": "Lokale Notizbreiten zurücksetzen",
+	"settings.reset_local_overrides.desc": "Entfernt alle lokal gespeicherten Breiten für einzelne Notizen.",
+	"settings.reset_local_overrides.button": "Zurücksetzen",
 	"settings.yaml_key.name": "YAML-Frontmatter-Schlüssel",
-	"settings.yaml_key.desc": "YAML-Frontmatter-Schlüssel für die individuelle Breite festlegen.",
+	"settings.yaml_key.desc": "Frontmatter-Schlüssel für die Notizbreite.",
 
 	// Settings — Code Block
 	"settings.enable_code_block.name": "Codeblock-Breite aktivieren",
@@ -224,6 +252,14 @@ const ru: Translations = {
 
 	// Notices
 	"notice.slider_too_large": "Значение ползунка слишком большое!",
+	"notice.local_overrides_cleared": "Удалено локальных ширин: {{count}}.",
+	"notice.local_overrides_empty": "Нет локальных ширин для сброса.",
+	"modal.reset_overrides.title": "Сброс локальных ширин заметок",
+	"modal.reset_overrides.desc": "У {{count}} заметок(и) есть локально сохранённая ширина. Выберите, какие удалить.",
+	"modal.reset_overrides.search_placeholder": "Фильтр по пути…",
+	"modal.reset_overrides.select_all": "Выбрать все",
+	"modal.reset_overrides.empty_filter": "Нет совпадений.",
+	"modal.reset_overrides.remove": "Удалить: {{count}}",
 
 	// Progress modals
 	"progress.changing_keys": "Изменение всех ключей YAML свойств заметки…",
@@ -259,11 +295,17 @@ const ru: Translations = {
 
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Включить индивидуальную ширину заметок",
-	"settings.enable_per_note.desc": "Разрешить задавать отдельную ширину для каждой заметки через свойства заметки.",
-	"settings.auto_save_yaml.name": "Автоматически сохранять в YAML",
-	"settings.auto_save_yaml.desc": "Когда включено, изменения ширины сохраняются в YAML-свойства заметки. Отключите, чтобы менять ширину только на время сеанса, не изменяя файл.",
+	"settings.enable_per_note.desc": "Если включено, заметки могут иметь собственную ширину вместо глобальной по умолчанию.",
+	"settings.per_note_mode.name": "Где хранится ширина заметки",
+	"settings.per_note_mode.desc": "Выберите, где хранятся ширины заметок. 'Frontmatter' записывает их в саму заметку. 'Локально' сохраняет их для каждой заметки в плагине, не трогая файл. 'Только в виде' сохраняет изменение до закрытия заметки, затем сбрасывает.",
+	"settings.per_note_mode.option.frontmatter": "Frontmatter",
+	"settings.per_note_mode.option.local": "Локально",
+	"settings.per_note_mode.option.view_only": "Только в виде",
+	"settings.reset_local_overrides.name": "Сбросить локальные ширины",
+	"settings.reset_local_overrides.desc": "Удалить все локально сохранённые ширины для отдельных заметок.",
+	"settings.reset_local_overrides.button": "Сбросить",
 	"settings.yaml_key.name": "Ключ YAML свойства заметки",
-	"settings.yaml_key.desc": "Укажите ключ YAML свойства заметки для управления шириной редактора.",
+	"settings.yaml_key.desc": "Ключ свойства для хранения ширины заметки.",
 
 	// Settings — Code Block
 	"settings.enable_code_block.name": "Включить регулировку ширины блоков кода",

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -100,6 +100,8 @@ const en: Translations = {
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Enable per-note width",
 	"settings.enable_per_note.desc": "Enable to set individual widths per note via YAML frontmatter.",
+	"settings.auto_save_yaml.name": "Automatically save to YAML",
+	"settings.auto_save_yaml.desc": "When enabled, slider changes are immediately saved to the note's YAML frontmatter. Disable to use the slider without modifying the file.",
 	"settings.yaml_key.name": "YAML front matter key",
 	"settings.yaml_key.desc": "Specify the YAML front matter key to use for setting the custom width of the editor.",
 
@@ -178,8 +180,10 @@ const de: Translations = {
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Individuelle Notizbreite",
 	"settings.enable_per_note.desc": "Individuelle Breite pro Notiz per YAML-Frontmatter setzen.",
-	"settings.yaml_key.name": "YAML-Frontmatter-Schl\u00FCssel",
-	"settings.yaml_key.desc": "YAML-Frontmatter-Schl\u00FCssel f\u00FCr die individuelle Breite festlegen.",
+	"settings.auto_save_yaml.name": "Automatisch in YAML speichern",
+	"settings.auto_save_yaml.desc": "Wenn aktiviert, werden Schieberegler-Änderungen sofort im YAML-Frontmatter gespeichert. Deaktivieren, um den Schieberegler ohne Dateiänderung zu nutzen.",
+	"settings.yaml_key.name": "YAML-Frontmatter-Schlüssel",
+	"settings.yaml_key.desc": "YAML-Frontmatter-Schlüssel für die individuelle Breite festlegen.",
 
 	// Settings — Code Block
 	"settings.enable_code_block.name": "Codeblock-Breite aktivieren",
@@ -256,6 +260,8 @@ const ru: Translations = {
 	// Settings — Per-Note
 	"settings.enable_per_note.name": "Включить индивидуальную ширину заметок",
 	"settings.enable_per_note.desc": "Разрешить задавать отдельную ширину для каждой заметки через свойства заметки.",
+	"settings.auto_save_yaml.name": "Автоматически сохранять в YAML",
+	"settings.auto_save_yaml.desc": "Когда включено, изменения ползунка сразу сохраняются в YAML-свойства заметки. Отключите, чтобы использовать ползунок без изменения файла.",
 	"settings.yaml_key.name": "Ключ YAML свойства заметки",
 	"settings.yaml_key.desc": "Укажите ключ YAML свойства заметки для управления шириной редактора.",
 

--- a/src/modals/resetOverridesModal.ts
+++ b/src/modals/resetOverridesModal.ts
@@ -1,0 +1,235 @@
+import { App, Modal } from "obsidian";
+import { t } from "src/i18n/i18n";
+import { WidthValue } from "src/utility/config";
+
+interface Row
+{
+	path: string;
+	container: HTMLDivElement;
+	checkbox: HTMLInputElement;
+}
+
+/**
+ * Modal with a searchable checkbox list of local per-note overrides.
+ * The user picks which ones to remove; the caller receives the selected paths on confirm.
+ */
+export default class ResetOverridesModal extends Modal
+{
+	private rows: Row[] = [];
+	private selectAllBox: HTMLInputElement | null = null;
+	private selectAllLabel: HTMLLabelElement | null = null;
+	private removeBtn: HTMLButtonElement | null = null;
+	private emptyEl: HTMLDivElement | null = null;
+	private filter = "";
+
+	/**
+	 * Constructs a new ResetOverridesModal.
+	 * @param app - The Obsidian application instance.
+	 * @param overrides - Map of file paths to their stored WidthValue.
+	 * @param onConfirm - Callback invoked with the paths the user chose to remove.
+	 */
+	constructor(
+		app: App,
+		private overrides: Record<string, WidthValue>,
+		private onConfirm: (paths: string[]) => void | Promise<void>,
+	)
+	{
+		super(app);
+	}
+
+	/** Opens the modal and builds its content. */
+	public onOpen(): void
+	{
+		const { contentEl, titleEl } = this;
+		titleEl.setText(t("modal.reset_overrides.title"));
+
+		const paths = Object.keys(this.overrides).sort();
+
+		contentEl.createEl("p", {
+			text: t("modal.reset_overrides.desc", { count: paths.length }),
+		});
+
+		this.renderSearch(contentEl);
+		this.renderSelectAll(contentEl);
+		this.renderList(contentEl, paths);
+		this.renderButtons(contentEl);
+		this.applyFilter();
+	}
+
+	/** Search input; live-filters the list. */
+	private renderSearch(container: HTMLElement): void
+	{
+		const input = container.createEl("input", { type: "text" });
+		input.placeholder = t("modal.reset_overrides.search_placeholder");
+		input.style.width = "100%";
+		input.style.marginBottom = "8px";
+		input.style.padding = "6px 8px";
+		input.oninput = () =>
+		{
+			this.filter = input.value.trim().toLowerCase();
+			this.applyFilter();
+		};
+	}
+
+	/** Master "select all" checkbox row; operates on the currently visible rows. */
+	private renderSelectAll(container: HTMLElement): void
+	{
+		const row = container.createDiv({ cls: "cnw-reset-select-all" });
+		row.style.display = "flex";
+		row.style.alignItems = "center";
+		row.style.gap = "8px";
+		row.style.padding = "6px 4px";
+		row.style.borderBottom = "1px solid var(--background-modifier-border)";
+		row.style.marginBottom = "6px";
+		row.style.fontWeight = "500";
+
+		this.selectAllBox = row.createEl("input", { type: "checkbox" });
+		this.selectAllBox.checked = true;
+		this.selectAllBox.id = "cnw-select-all";
+		this.selectAllBox.onchange = () =>
+		{
+			const target = this.selectAllBox?.checked ?? false;
+			for (const r of this.visibleRows())
+			{
+				r.checkbox.checked = target;
+			}
+			this.syncSelectAll();
+			this.refreshRemoveButton();
+		};
+
+		this.selectAllLabel = row.createEl("label");
+		this.selectAllLabel.htmlFor = "cnw-select-all";
+		this.selectAllLabel.style.cursor = "pointer";
+		this.selectAllLabel.style.userSelect = "none";
+	}
+
+	/** Scrollable list; one row per override. */
+	private renderList(container: HTMLElement, paths: string[]): void
+	{
+		const listEl = container.createDiv({ cls: "cnw-reset-list" });
+		// Fixed height so the modal keeps its size while the search filter shrinks the list.
+		listEl.style.height = "320px";
+		listEl.style.overflowY = "auto";
+		listEl.style.margin = "0 0 8px";
+		listEl.style.paddingRight = "6px";
+		listEl.style.border = "1px solid var(--background-modifier-border)";
+		listEl.style.borderRadius = "4px";
+
+		for (const path of paths)
+		{
+			const wv = this.overrides[path];
+			const row = listEl.createDiv({ cls: "cnw-reset-row" });
+			row.style.display = "flex";
+			row.style.alignItems = "center";
+			row.style.gap = "8px";
+			row.style.padding = "4px 8px";
+			row.style.borderBottom = "1px solid var(--background-modifier-border-hover)";
+
+			const checkbox = row.createEl("input", { type: "checkbox" });
+			checkbox.checked = true;
+			checkbox.id = `cnw-reset-${this.rows.length}`;
+			checkbox.onchange = () =>
+			{
+				this.syncSelectAll();
+				this.refreshRemoveButton();
+			};
+
+			const label = row.createEl("label");
+			label.htmlFor = checkbox.id;
+			label.style.cursor = "pointer";
+			label.style.userSelect = "none";
+			label.style.flex = "1";
+			label.style.overflow = "hidden";
+			label.style.textOverflow = "ellipsis";
+			label.style.whiteSpace = "nowrap";
+			label.setText(path);
+			label.title = path;
+
+			const value = row.createEl("span", { text: `${wv.value}${wv.unit}` });
+			value.style.color = "var(--text-muted)";
+			value.style.fontSize = "var(--font-ui-smaller)";
+			value.style.fontVariantNumeric = "tabular-nums";
+			value.style.minWidth = "48px";
+			value.style.textAlign = "right";
+
+			this.rows.push({ path, container: row, checkbox });
+		}
+
+		this.emptyEl = listEl.createDiv({ text: t("modal.reset_overrides.empty_filter") });
+		this.emptyEl.style.padding = "12px";
+		this.emptyEl.style.textAlign = "center";
+		this.emptyEl.style.color = "var(--text-muted)";
+		this.emptyEl.style.display = "none";
+	}
+
+	/** Cancel / Remove buttons. */
+	private renderButtons(container: HTMLElement): void
+	{
+		const buttonRow = container.createDiv();
+		buttonRow.style.display = "flex";
+		buttonRow.style.justifyContent = "flex-end";
+		buttonRow.style.gap = "8px";
+
+		const cancelBtn = buttonRow.createEl("button", { text: t("button.cancel") });
+		cancelBtn.onclick = () => this.close();
+
+		this.removeBtn = buttonRow.createEl("button", { cls: "mod-warning" });
+		this.removeBtn.onclick = async () =>
+		{
+			const paths = this.rows.filter((r) => r.checkbox.checked).map((r) => r.path);
+			this.close();
+			await this.onConfirm(paths);
+		};
+	}
+
+	/** Show or hide each row based on the current filter. */
+	private applyFilter(): void
+	{
+		let visible = 0;
+		for (const r of this.rows)
+		{
+			const match = this.filter === "" || r.path.toLowerCase().includes(this.filter);
+			r.container.style.display = match ? "" : "none";
+			if (match) visible++;
+		}
+		if (this.emptyEl)
+		{
+			this.emptyEl.style.display = visible === 0 ? "" : "none";
+		}
+		this.syncSelectAll();
+		this.refreshRemoveButton();
+	}
+
+	/** All rows currently passing the filter. */
+	private visibleRows(): Row[]
+	{
+		return this.rows.filter((r) => r.container.style.display !== "none");
+	}
+
+	/**
+	 * Master checkbox reflects the state of the *visible* rows.
+	 * Its label counts them, so the user always sees what the toggle will act on.
+	 */
+	private syncSelectAll(): void
+	{
+		if (!this.selectAllBox || !this.selectAllLabel) return;
+		const visible = this.visibleRows();
+		const checkedVisible = visible.filter((r) => r.checkbox.checked).length;
+		this.selectAllBox.checked = visible.length > 0 && checkedVisible === visible.length;
+		this.selectAllBox.indeterminate = checkedVisible > 0 && checkedVisible < visible.length;
+		this.selectAllBox.disabled = visible.length === 0;
+		this.selectAllLabel.setText(`${t("modal.reset_overrides.select_all")} (${visible.length})`);
+	}
+
+	/**
+	 * Remove button counts every selected entry, including hidden ones, so a
+	 * search filter does not silently understate what the button will delete.
+	 */
+	private refreshRemoveButton(): void
+	{
+		if (!this.removeBtn) return;
+		const count = this.rows.filter((r) => r.checkbox.checked).length;
+		this.removeBtn.setText(t("modal.reset_overrides.remove", { count }));
+		this.removeBtn.disabled = count === 0;
+	}
+}

--- a/src/note/noteWidthManager.ts
+++ b/src/note/noteWidthManager.ts
@@ -24,13 +24,8 @@ export default class NoteWidthManager
 	private leafCodeBlockRules: Map<string, string> = new Map();
 	/** Counter for generating unique leaf IDs. */
 	private leafIdCounter: number = 0;
-	/**
-	 * Session-only widths keyed by file path, used when auto-save to YAML is
-	 * disabled: the slider adjusts the visual width without modifying the file,
-	 * and this map keeps the adjustment alive across tab switches and layout
-	 * changes. Cleared on plugin restart.
-	 */
-	private tempWidths: Map<string, WidthValue> = new Map();
+	/** Session-only widths (per-note mode 'view-only'), dropped when the note is closed. */
+	private viewOnlyWidths: Map<string, WidthValue> = new Map();
 
 	/**
 	 * Constructs a new NoteWidthManager instance.
@@ -130,13 +125,27 @@ export default class NoteWidthManager
 			return defaultWv;
 		}
 
-		// Session-only width set via the slider with auto-save to YAML
-		// disabled: it takes precedence over the frontmatter so the
-		// adjustment survives tab switches and layout changes.
-		const temp = this.tempWidths.get(file.path);
-		if (temp)
+		const mode = this.plugin.settingsManager.getPerNoteMode();
+
+		// In 'local' / 'view-only' the per-mode store shadows the frontmatter;
+		// the frontmatter still acts as the initial value when no entry exists.
+		if (mode === 'local')
 		{
-			return temp;
+			const override = this.plugin.settingsManager.getLocalOverrides()[file.path];
+			if (override)
+			{
+				const unitConfig = this.plugin.settingsManager.getUnitConfig(override.unit);
+				return validateWidthValue(override, unitConfig);
+			}
+		}
+		else if (mode === 'view-only')
+		{
+			const view = this.viewOnlyWidths.get(file.path);
+			if (view)
+			{
+				const unitConfig = this.plugin.settingsManager.getUnitConfig(view.unit);
+				return validateWidthValue(view, unitConfig);
+			}
 		}
 
 		const yamlKey = this.plugin.settingsManager.getYAMLKey();
@@ -202,26 +211,56 @@ export default class NoteWidthManager
 		this.plugin.uiManager.updatePillsActiveState(wv);
 	}
 
-	/**
-	 * Stores a session-only width for a file. Used when auto-save to YAML is
-	 * disabled so the visual adjustment survives tab switches and layout
-	 * changes. Cleared on plugin restart.
-	 * @param path - The file path.
-	 * @param wv - The WidthValue to apply for this session.
-	 */
-	public setTempWidth(path: string, wv: WidthValue): void
+	/** Stores a view-only width for a file. */
+	public setViewOnlyWidth(path: string, wv: WidthValue): void
 	{
-		this.tempWidths.set(path, wv);
+		this.viewOnlyWidths.set(path, wv);
 	}
 
-	/**
-	 * Removes a session-only width for a file. Used when auto-save to YAML is
-	 * re-enabled so the frontmatter becomes authoritative again.
-	 * @param path - The file path.
-	 */
-	public clearTempWidth(path: string): void
+	/** Removes the view-only width for a file. */
+	public clearViewOnlyWidth(path: string): void
 	{
-		this.tempWidths.delete(path);
+		this.viewOnlyWidths.delete(path);
+	}
+
+	/** Moves a view-only entry to a new path (used on rename). */
+	public renameViewOnlyWidth(oldPath: string, newPath: string): void
+	{
+		const wv = this.viewOnlyWidths.get(oldPath);
+		if (!wv) return;
+		this.viewOnlyWidths.delete(oldPath);
+		this.viewOnlyWidths.set(newPath, wv);
+	}
+
+	/** Drops view-only entries for files that no longer have any open leaf. */
+	public cleanupViewOnlyWidths(): void
+	{
+		if (this.viewOnlyWidths.size === 0) return;
+
+		const openPaths = new Set<string>();
+		this.app.workspace.iterateAllLeaves((leaf) =>
+		{
+			if (leaf.view instanceof MarkdownView && leaf.view.file)
+			{
+				openPaths.add(leaf.view.file.path);
+			}
+		});
+
+		for (const path of this.viewOnlyWidths.keys())
+		{
+			if (!openPaths.has(path))
+			{
+				this.viewOnlyWidths.delete(path);
+			}
+		}
+	}
+
+	/** Removes every view-only entry. Returns the number that were removed. */
+	public clearAllViewOnlyWidths(): number
+	{
+		const count = this.viewOnlyWidths.size;
+		this.viewOnlyWidths.clear();
+		return count;
 	}
 
 	/**
@@ -249,7 +288,7 @@ export default class NoteWidthManager
 	public destroy(): void
 	{
 		this.removeNoteWidthEditorStyle();
-		this.tempWidths.clear();
+		this.viewOnlyWidths.clear();
 		this.styleElement.remove();
 	}
 

--- a/src/note/noteWidthManager.ts
+++ b/src/note/noteWidthManager.ts
@@ -24,6 +24,13 @@ export default class NoteWidthManager
 	private leafCodeBlockRules: Map<string, string> = new Map();
 	/** Counter for generating unique leaf IDs. */
 	private leafIdCounter: number = 0;
+	/**
+	 * Session-only widths keyed by file path, used when auto-save to YAML is
+	 * disabled: the slider adjusts the visual width without modifying the file,
+	 * and this map keeps the adjustment alive across tab switches and layout
+	 * changes. Cleared on plugin restart.
+	 */
+	private tempWidths: Map<string, WidthValue> = new Map();
 
 	/**
 	 * Constructs a new NoteWidthManager instance.
@@ -123,6 +130,15 @@ export default class NoteWidthManager
 			return defaultWv;
 		}
 
+		// Session-only width set via the slider with auto-save to YAML
+		// disabled: it takes precedence over the frontmatter so the
+		// adjustment survives tab switches and layout changes.
+		const temp = this.tempWidths.get(file.path);
+		if (temp)
+		{
+			return temp;
+		}
+
 		const yamlKey = this.plugin.settingsManager.getYAMLKey();
 		const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
 
@@ -187,6 +203,28 @@ export default class NoteWidthManager
 	}
 
 	/**
+	 * Stores a session-only width for a file. Used when auto-save to YAML is
+	 * disabled so the visual adjustment survives tab switches and layout
+	 * changes. Cleared on plugin restart.
+	 * @param path - The file path.
+	 * @param wv - The WidthValue to apply for this session.
+	 */
+	public setTempWidth(path: string, wv: WidthValue): void
+	{
+		this.tempWidths.set(path, wv);
+	}
+
+	/**
+	 * Removes a session-only width for a file. Used when auto-save to YAML is
+	 * re-enabled so the frontmatter becomes authoritative again.
+	 * @param path - The file path.
+	 */
+	public clearTempWidth(path: string): void
+	{
+		this.tempWidths.delete(path);
+	}
+
+	/**
 	 * Removes all custom width styles from all views and clears leaf rules.
 	 */
 	public removeNoteWidthEditorStyle(): void
@@ -211,6 +249,7 @@ export default class NoteWidthManager
 	public destroy(): void
 	{
 		this.removeNoteWidthEditorStyle();
+		this.tempWidths.clear();
 		this.styleElement.remove();
 	}
 

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -24,6 +24,8 @@ export interface CustomNoteWidthSettings
 	enableSlider: boolean;
 	enableTextInput: boolean;
 	enablePerNoteWidth: boolean;
+	/** Whether to automatically write the width to YAML frontmatter when the slider changes. */
+	autoSaveYaml: boolean;
 	unitRanges: Record<WidthUnit, UnitRange>;
 	enableCodeBlockWidth: boolean;
 	codeBlockWidth: number;
@@ -50,6 +52,7 @@ export default class SettingsManager
 		enableSlider: true,
 		enableTextInput: true,
 		enablePerNoteWidth: true,
+		autoSaveYaml: true,
 		unitRanges: {
 			'%': { min: 0, max: 100 },
 			'px': { min: 100, max: 4000 },
@@ -140,6 +143,16 @@ export default class SettingsManager
 	public getEnablePerNoteWidth(): boolean
 	{
 		return this.getSetting("enablePerNoteWidth");
+	}
+
+	/**
+	 * Retrieves the auto-save YAML setting.
+	 * When enabled, slider changes are automatically persisted to YAML frontmatter.
+	 * @returns - Whether auto-save to YAML is enabled.
+	 */
+	public getAutoSaveYaml(): boolean
+	{
+		return this.getSetting("autoSaveYaml");
 	}
 
 	/**
@@ -292,6 +305,12 @@ export default class SettingsManager
 		if (loaded && !('controlMode' in loaded))
 		{
 			loaded.controlMode = 'slider';
+		}
+
+		// Ensure autoSaveYaml exists (migration from versions before the toggle was added)
+		if (loaded && !('autoSaveYaml' in loaded))
+		{
+			loaded.autoSaveYaml = true;
 		}
 		if (loaded && (!('pillsPresets' in loaded) || !Array.isArray(loaded.pillsPresets) || loaded.pillsPresets.length !== PILLS_PRESET_COUNT))
 		{

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -8,6 +8,8 @@ import {
 	PillsPreset,
 	DEFAULT_PILLS_PRESETS,
 	PILLS_PRESET_COUNT,
+	PerNoteMode,
+	WidthValue,
 } from "src/utility/config";
 import { setLocaleOverride } from "src/i18n/i18n";
 
@@ -24,8 +26,10 @@ export interface CustomNoteWidthSettings
 	enableSlider: boolean;
 	enableTextInput: boolean;
 	enablePerNoteWidth: boolean;
-	/** Whether to automatically write the width to YAML frontmatter when the slider changes. */
-	autoSaveYaml: boolean;
+	/** Where per-note widths are stored ('frontmatter', 'local', or 'view-only'). */
+	perNoteMode: PerNoteMode;
+	/** Local per-note width overrides keyed by file path, used in 'local' mode. */
+	localOverrides: Record<string, WidthValue>;
 	unitRanges: Record<WidthUnit, UnitRange>;
 	enableCodeBlockWidth: boolean;
 	codeBlockWidth: number;
@@ -52,7 +56,8 @@ export default class SettingsManager
 		enableSlider: true,
 		enableTextInput: true,
 		enablePerNoteWidth: true,
-		autoSaveYaml: true,
+		perNoteMode: 'frontmatter',
+		localOverrides: {},
 		unitRanges: {
 			'%': { min: 0, max: 100 },
 			'px': { min: 100, max: 4000 },
@@ -145,14 +150,16 @@ export default class SettingsManager
 		return this.getSetting("enablePerNoteWidth");
 	}
 
-	/**
-	 * Retrieves the auto-save YAML setting.
-	 * When enabled, slider changes are automatically persisted to YAML frontmatter.
-	 * @returns - Whether auto-save to YAML is enabled.
-	 */
-	public getAutoSaveYaml(): boolean
+	/** Retrieves the per-note storage mode. */
+	public getPerNoteMode(): PerNoteMode
 	{
-		return this.getSetting("autoSaveYaml");
+		return this.getSetting("perNoteMode");
+	}
+
+	/** Retrieves the local overrides map. */
+	public getLocalOverrides(): Record<string, WidthValue>
+	{
+		return this.getSetting("localOverrides");
 	}
 
 	/**
@@ -307,11 +314,21 @@ export default class SettingsManager
 			loaded.controlMode = 'slider';
 		}
 
-		// Ensure autoSaveYaml exists (migration from versions before the toggle was added)
-		if (loaded && !('autoSaveYaml' in loaded))
+		// Migrate autoSaveYaml (old boolean toggle) to the three-way perNoteMode.
+		if (loaded && !('perNoteMode' in loaded))
 		{
-			loaded.autoSaveYaml = true;
+			loaded.perNoteMode = (loaded.autoSaveYaml === false) ? 'view-only' : 'frontmatter';
 		}
+		if (loaded && 'autoSaveYaml' in loaded)
+		{
+			delete loaded.autoSaveYaml;
+		}
+
+		if (loaded && !('localOverrides' in loaded))
+		{
+			loaded.localOverrides = {};
+		}
+
 		if (loaded && (!('pillsPresets' in loaded) || !Array.isArray(loaded.pillsPresets) || loaded.pillsPresets.length !== PILLS_PRESET_COUNT))
 		{
 			loaded.pillsPresets = [...DEFAULT_PILLS_PRESETS];
@@ -331,6 +348,41 @@ export default class SettingsManager
 	{
 		this.settings = settings;
 		await this.plugin.saveData(settings);
+	}
+
+	/** Stores a per-note width in the local overrides map and persists it. */
+	public async setLocalOverride(path: string, wv: WidthValue): Promise<void>
+	{
+		const updated = { ...this.settings.localOverrides, [path]: wv };
+		await this.saveSettings({ ...this.settings, localOverrides: updated });
+	}
+
+	/** Removes a per-note width from the local overrides map. */
+	public async clearLocalOverride(path: string): Promise<void>
+	{
+		if (!(path in this.settings.localOverrides)) return;
+		const updated = { ...this.settings.localOverrides };
+		delete updated[path];
+		await this.saveSettings({ ...this.settings, localOverrides: updated });
+	}
+
+	/** Moves a local override to a new path (used on rename). */
+	public async renameLocalOverride(oldPath: string, newPath: string): Promise<void>
+	{
+		if (!(oldPath in this.settings.localOverrides)) return;
+		const updated = { ...this.settings.localOverrides };
+		updated[newPath] = updated[oldPath];
+		delete updated[oldPath];
+		await this.saveSettings({ ...this.settings, localOverrides: updated });
+	}
+
+	/** Clears every local override. Returns the number that were removed. */
+	public async clearAllLocalOverrides(): Promise<number>
+	{
+		const count = Object.keys(this.settings.localOverrides).length;
+		if (count === 0) return 0;
+		await this.saveSettings({ ...this.settings, localOverrides: {} });
+		return count;
 	}
 
 }

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -390,9 +390,25 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 				});
 			});
 
-		// Only show YAML key setting if per-note width is enabled
+		// Only show per-note sub-settings if per-note width is enabled
 		if (this.plugin.settingsManager.getEnablePerNoteWidth())
 		{
+			// Auto-save to YAML toggle
+			new Setting(containerEl)
+				.setName(t("settings.auto_save_yaml.name"))
+				.setDesc(t("settings.auto_save_yaml.desc"))
+				.addToggle((cb: ToggleComponent) =>
+				{
+					cb.setValue(this.plugin.settingsManager.getAutoSaveYaml());
+					cb.onChange(async (value: boolean) =>
+					{
+						await this.plugin.settingsManager.saveSettings({
+							...this.plugin.settingsManager.settings,
+							autoSaveYaml: value,
+						});
+					});
+				});
+
 			new Setting(containerEl)
 				.setName(t("settings.yaml_key.name"))
 				.setDesc(t("settings.yaml_key.desc"))

--- a/src/settings/settingsTab.ts
+++ b/src/settings/settingsTab.ts
@@ -3,9 +3,10 @@ import type CustomNoteWidth from "src/main";
 import DonationButton from "src/settings/donationButton";
 import YamlFrontMatterProcessor from "src/note/yamlFrontMatterProcessor";
 import ProgressBarModal from "src/modals/progressBarModal";
+import ResetOverridesModal from "src/modals/resetOverridesModal";
 import { PLUGIN_NAME } from "src/utility/constants";
 import { t, setLocaleOverride, SUPPORTED_LOCALES } from "src/i18n/i18n";
-import { WidthUnit, UNIT_CONFIGS, VALID_UNITS, UNIT_ABSOLUTE_BOUNDS, ControlMode, PillsPreset } from "src/utility/config";
+import { WidthUnit, UNIT_CONFIGS, VALID_UNITS, UNIT_ABSOLUTE_BOUNDS, ControlMode, PerNoteMode, PillsPreset } from "src/utility/config";
 
 /**
  * Represents the settings tab for the CustomNoteWidth plugin.
@@ -25,6 +26,40 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 		super(app, plugin);
 		this.donationButton = new DonationButton();
 		this.yamlProcessor = new YamlFrontMatterProcessor(app);
+	}
+
+	/**
+	 * Re-renders the settings tab without losing the current scroll position.
+	 * Obsidian rebuilds containerEl on display() and resets scroll to the top.
+	 */
+	private redrawKeepingScroll(): void
+	{
+		const scroller = this.findScrollableAncestor();
+		const scroll = scroller?.scrollTop ?? 0;
+		this.display();
+		if (scroller && scroll > 0)
+		{
+			requestAnimationFrame(() =>
+			{
+				scroller.scrollTop = scroll;
+			});
+		}
+	}
+
+	/** Finds the ancestor element that actually scrolls the settings tab. */
+	private findScrollableAncestor(): HTMLElement | null
+	{
+		let el: HTMLElement | null = this.containerEl;
+		while (el)
+		{
+			const overflowY = window.getComputedStyle(el).overflowY;
+			if ((overflowY === 'auto' || overflowY === 'scroll') && el.scrollHeight > el.clientHeight)
+			{
+				return el;
+			}
+			el = el.parentElement;
+		}
+		return null;
 	}
 
 	public display(): void
@@ -54,7 +89,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						...this.plugin.settingsManager.settings,
 						language: value,
 					});
-					this.display();
+					this.redrawKeepingScroll();
 				});
 			});
 
@@ -74,7 +109,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						enableSlider: value,
 					});
 					this.plugin.uiManager.updateUI();
-					this.display();
+					this.redrawKeepingScroll();
 				});
 			});
 
@@ -96,7 +131,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 							controlMode: value as ControlMode,
 						});
 						this.plugin.uiManager.updateUI();
-						this.display();
+						this.redrawKeepingScroll();
 					});
 				});
 		}
@@ -156,7 +191,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 								pillsPresets: currentPresets,
 							});
 							this.plugin.uiManager.updateUI();
-							this.display();
+							this.redrawKeepingScroll();
 						});
 					});
 			});
@@ -227,7 +262,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						enableTextInput: value,
 					});
 					this.plugin.uiManager.updateUI();
-					this.display();
+					this.redrawKeepingScroll();
 				});
 			});
 
@@ -262,7 +297,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						defaultWidth: currentWidth,
 					});
 					this.plugin.uiManager.updateUI();
-					this.display();
+					this.redrawKeepingScroll();
 				});
 			});
 
@@ -386,28 +421,74 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						...this.plugin.settingsManager.settings,
 						enablePerNoteWidth: value,
 					});
-					this.display();
+					// Discard any session-only widths so the frontmatter is
+					// authoritative again as soon as per-note mode is toggled.
+					this.plugin.noteWidthManager.clearAllViewOnlyWidths();
+					this.plugin.noteWidthManager.applyWidthForLeaf();
+					this.redrawKeepingScroll();
 				});
 			});
 
 		// Only show per-note sub-settings if per-note width is enabled
 		if (this.plugin.settingsManager.getEnablePerNoteWidth())
 		{
-			// Auto-save to YAML toggle
+			// Per-note storage mode
 			new Setting(containerEl)
-				.setName(t("settings.auto_save_yaml.name"))
-				.setDesc(t("settings.auto_save_yaml.desc"))
-				.addToggle((cb: ToggleComponent) =>
+				.setName(t("settings.per_note_mode.name"))
+				.setDesc(t("settings.per_note_mode.desc"))
+				.addDropdown((dropdown) =>
 				{
-					cb.setValue(this.plugin.settingsManager.getAutoSaveYaml());
-					cb.onChange(async (value: boolean) =>
+					dropdown.addOption("frontmatter", t("settings.per_note_mode.option.frontmatter"));
+					dropdown.addOption("local", t("settings.per_note_mode.option.local"));
+					dropdown.addOption("view-only", t("settings.per_note_mode.option.view_only"));
+					dropdown.setValue(this.plugin.settingsManager.getPerNoteMode());
+					dropdown.onChange(async (value) =>
 					{
 						await this.plugin.settingsManager.saveSettings({
 							...this.plugin.settingsManager.settings,
-							autoSaveYaml: value,
+							perNoteMode: value as PerNoteMode,
 						});
+						// A mode switch invalidates the previous source of
+						// truth. Drop session-only widths so the new mode is
+						// visible immediately without a stale value shadowing
+						// the frontmatter (or a local override).
+						this.plugin.noteWidthManager.clearAllViewOnlyWidths();
+						this.plugin.noteWidthManager.applyWidthForLeaf();
+						this.redrawKeepingScroll();
 					});
 				});
+
+			// Reset button for local overrides — only relevant in 'local' mode
+			if (this.plugin.settingsManager.getPerNoteMode() === 'local')
+			{
+				new Setting(containerEl)
+					.setName(t("settings.reset_local_overrides.name"))
+					.setDesc(t("settings.reset_local_overrides.desc"))
+					.addButton((btn) =>
+					{
+						btn.setButtonText(t("settings.reset_local_overrides.button"));
+						btn.setWarning();
+						btn.onClick(() =>
+						{
+							const overrides = this.plugin.settingsManager.getLocalOverrides();
+							if (Object.keys(overrides).length === 0)
+							{
+								new Notice(t("notice.local_overrides_empty"));
+								return;
+							}
+							new ResetOverridesModal(this.app, overrides, async (paths) =>
+							{
+								if (paths.length === 0) return;
+								for (const path of paths)
+								{
+									await this.plugin.settingsManager.clearLocalOverride(path);
+								}
+								new Notice(t("notice.local_overrides_cleared", { count: paths.length }));
+								this.plugin.noteWidthManager.applyWidthForLeaf();
+							}).open();
+						});
+					});
+			}
 
 			new Setting(containerEl)
 				.setName(t("settings.yaml_key.name"))
@@ -466,7 +547,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 						enableCodeBlockWidth: value,
 					});
 					this.plugin.noteWidthManager.applyWidthForLeaf();
-					this.display();
+					this.redrawKeepingScroll();
 				});
 			});
 
@@ -500,7 +581,7 @@ export default class CustomNoteWidthSettingTab extends PluginSettingTab
 							codeBlockWidth: currentWidth,
 						});
 						this.plugin.noteWidthManager.applyWidthForLeaf();
-						this.display();
+						this.redrawKeepingScroll();
 					});
 				});
 

--- a/src/utility/config.ts
+++ b/src/utility/config.ts
@@ -64,6 +64,19 @@ export interface UnitRange
 export type ControlMode = 'slider' | 'pills';
 
 /**
+ * Where per-note widths are stored when `enablePerNoteWidth` is on.
+ * - 'frontmatter' writes to the note's YAML frontmatter (original behaviour, shared across devices).
+ * - 'local' persists per-note widths in the plugin's data.json, keeping the note file untouched.
+ * - 'view-only' keeps the adjustment in memory while the note is open, then discards it.
+ */
+export type PerNoteMode = 'frontmatter' | 'local' | 'view-only';
+
+/**
+ * Ordered list of valid per-note storage modes.
+ */
+export const VALID_PER_NOTE_MODES: PerNoteMode[] = ['frontmatter', 'local', 'view-only'];
+
+/**
  * A single pills preset: width value with its unit.
  */
 export interface PillsPreset


### PR DESCRIPTION
### Problem

When `enablePerNoteWidth` is on, every slider interaction immediately writes the width value to the note's YAML frontmatter. This creates friction in **shared / multi-user vaults**:

- User A sets a custom width for a note (e.g. `custom-width: 700px`) — this is the *intended* width authored by the note's owner.
- User B opens the same note and adjusts the slider to fit their screen. The slider overwrites `custom-width` in the YAML, polluting the shared file and breaking User A's intent on every subsequent open.
- Even without shared vaults, some users prefer to tweak width temporarily without dirtying the file or triggering unnecessary Git diffs.

### Solution

A new setting **"Automatically save to YAML"** (`autoSaveYaml`) is added under `enablePerNoteWidth`:

| `enablePerNoteWidth` | `autoSaveYaml` | Slider / pills / unit selector → YAML | Commands (explicit user action) → YAML |
|---|---|---|---|
| OFF | — | ❌ (saves as default width in plugin settings) | — |
| ON | **ON** *(default)* | ✅ (existing behaviour, fully backwards-compatible) | ✅ |
| ON | OFF | ❌ (visual-only, the file is **never** modified) | ✅ |

When `autoSaveYaml` is **off**:
- The slider still reads the note's frontmatter to determine the starting width (`resolveWidthForFile` is unchanged) — authored widths are **always respected**.
- The slider changes width **visually in real-time** via `--file-line-width` but does **not** call `processFrontMatter`.
- Explicit commands (`Change the width of the open note`, `Change the width for all notes`, pill presets, unit selector, modal input) **continue to write to YAML** as before — these are deliberate user actions, not incidental slider drags.

### Changes

| File | Change |
|------|--------|
| `src/settings/settingsManager.ts` | Added `autoSaveYaml` field (interface, defaults, getter, migration) |
| `src/event/eventHandler.ts` | `saveWidth()` now gates YAML writes on `getAutoSaveYaml()` |
| `src/settings/settingsTab.ts` | New toggle UI under `enablePerNoteWidth` when per-note is enabled |
| `src/i18n/i18n.ts` | Translations for `settings.auto_save_yaml` in **en**, **de**, **ru** |

### Migration

Existing users are migrated seamlessly: `autoSaveYaml` defaults to `true`, preserving the current behaviour exactly. No breaking changes.

### Use cases

- **Shared vaults (Obsidian Sync, Git, Dropbox):** each collaborator can read the author's intended width while adjusting their own view without stepping on each other's files.
- **Git-tracked vaults:** slider tweaks no longer produce spurious diffs in frontmatter.
- **Temporary adjustments:** quickly widen a note for a code review, then switch back — the file stays clean.

<!--
Thanks for contributing! Please fill out the sections below.
-->

## Summary

<!-- What does this PR change, and why? -->

## Related issues

<!-- e.g. Closes #12, Related to #5 -->

## Testing

<!-- How did you test this change? -->
- [x] `npm run build` succeeds
- [x] Tested manually in the test vault
- [x] No regressions in existing features

## Screenshots / recordings

<img width="955" height="324" alt="Obsidian_UdtBgSKAjQ" src="https://github.com/user-attachments/assets/6b8280c7-43a9-4eb8-90d5-2dfc707929e1" />

## Checklist

- [x] I've read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] Code style matches the existing files
- [x] Commits have meaningful messages
